### PR TITLE
UTY-1376: added metric send system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Added a metric sending system for load, FPS and Unity heap usage.
+
 ### Fixed
+
 - Fixed an issue with the default snapshot that prevented the player lifecycle module from spawning a player.
 
 ## `0.1.2` - 2018-11-02

--- a/workers/unity/Assets/Scripts/MetricSendSystem.cs
+++ b/workers/unity/Assets/Scripts/MetricSendSystem.cs
@@ -1,0 +1,78 @@
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using Unity.Entities;
+using UnityEngine;
+
+namespace BlankProject
+{
+    public class MetricSendSystem : ComponentSystem
+    {
+        private Connection connection;
+
+        private float timeElapsedSinceUpdate;
+
+        private const float TimeBetweenMetricUpdatesSecs = 2.0f;
+        private const int DefaultTargetFrameRate = 60;
+
+        private float TargetFps;
+
+        private float totalFpsCount;
+        private int fpsMeasurements;
+
+        private Improbable.Worker.Metrics Metrics;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+            connection = World.GetExistingManager<WorkerSystem>().Connection;
+            Metrics = new Improbable.Worker.Metrics();
+
+            TargetFps = Application.targetFrameRate == -1
+                ? DefaultTargetFrameRate
+                : Application.targetFrameRate;
+        }
+
+        protected override void OnUpdate()
+        {
+            if (connection == null)
+            {
+                return;
+            }
+
+            timeElapsedSinceUpdate += Time.deltaTime;
+
+            AddFpsSample();
+            if (timeElapsedSinceUpdate >= TimeBetweenMetricUpdatesSecs)
+            {
+                timeElapsedSinceUpdate = 0;
+
+                var dynamicFps = CalculateFps();
+                Metrics.GaugeMetrics["Dynamic.FPS"] = dynamicFps;
+                Metrics.GaugeMetrics["Unity used heap size"] = GC.GetTotalMemory(false);
+                Metrics.Load = CalculateLoad(dynamicFps);
+
+                connection.SendMetrics(Metrics);
+            }
+        }
+
+        private float CalculateLoad(float dynamicFps)
+        {
+            return Mathf.Max(0.0f, 0.5f * TargetFps / dynamicFps);
+        }
+
+        private void AddFpsSample()
+        {
+            totalFpsCount += 1.0f / Time.deltaTime;
+            fpsMeasurements++;
+        }
+
+        private float CalculateFps()
+        {
+            var fps = totalFpsCount / fpsMeasurements;
+            totalFpsCount = 0;
+            fpsMeasurements = 0;
+            return fps;
+        }
+    }
+}

--- a/workers/unity/Assets/Scripts/MetricSendSystem.cs.meta
+++ b/workers/unity/Assets/Scripts/MetricSendSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cbabbfb47a604310b0cacf8ab17c1a6a
+timeCreated: 1541604290

--- a/workers/unity/Assets/Scripts/Workers/UnityGameLogicConnector.cs
+++ b/workers/unity/Assets/Scripts/Workers/UnityGameLogicConnector.cs
@@ -20,6 +20,7 @@ namespace BlankProject
 
         protected override void HandleWorkerConnectionEstablished()
         {
+            Worker.World.GetOrCreateManager<MetricSendSystem>();
             PlayerLifecycleHelper.AddServerSystems(Worker.World);
         }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/gdk-for-unity#give-us-feedback).

-------

#### Description
* redo load calculation
* simplify fps calculation
* add fps and unity heap use to sent metrics

##### PR Trifecta
Playground: https://github.com/spatialos/gdk-for-unity/pull/606
FPS Starter Project: https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/62
Blank Project: https://github.com/spatialos/gdk-for-unity-blank-project/pull/13

#### Tests
ran a deployment and looked at the numbers/charts

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.