### PR TITLE
Stop Unity from automatically creating the metrics system on the default world

### DIFF
--- a/workers/unity/Assets/Scripts/MetricSendSystem.cs
+++ b/workers/unity/Assets/Scripts/MetricSendSystem.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 
 namespace BlankProject
 {
+    [DisableAutoCreation]
     public class MetricSendSystem : ComponentSystem
     {
         private Connection connection;


### PR DESCRIPTION
#### Description
Added `[DisableAutoCreation]` tag to MetricSendSystem to fix a `NullReferenceException` in the default world.

#### Tests
Ran the project locally and saw the exception was gone.