### PR TITLE
Update release QA script

### DIFF
--- a/ci/launch.sh
+++ b/ci/launch.sh
@@ -18,6 +18,11 @@ uploadAssembly "${ASSEMBLY_PREFIX}" "${PROJECT_NAME}"
 
 echo "--- Launching deployment :airplane_departure:"
 
+# If the RUNTIME_VERSION env variable is already set, i.e. - through the Buildkite menu
+# then skip reading the file.
+if [[ -n $"{RUNTIME_VERSION:-}" ]]; then
+  export RUNTIME_VERSION="$(cat ../gdk-for-unity/workers/unity/Packages/io.improbable.gdk.tools/runtime.pinned)"
+fi
 
 dotnet run -p workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj -- \
     create \
@@ -27,7 +32,8 @@ dotnet run -p workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.Deplo
     --launch_json_path cloud_launch.json \
     --snapshot_path snapshots/default.snapshot \
     --region EU \
-    --tags "dev_login"
+    --tags "dev_login" \
+    --runtime_version="${RUNTIME_VERSION}"
 
 CONSOLE_URL="https://console.improbable.io/projects/${PROJECT_NAME}/deployments/${ASSEMBLY_NAME}/overview"
 

--- a/gdk.pinned
+++ b/gdk.pinned
@@ -1,1 +1,1 @@
-develop 19800e21d0cb65bc6c6546f7b6e4263de69249b6
+develop d3c1cf8fda5ee8fe50196cfcfb19aa33dd5a3894


### PR DESCRIPTION
As of https://github.com/spatialos/gdk-for-unity/pull/1299, the launch.sh scripts need the runtime version. This PR implements that change 