### PR TITLE
Fix "unbound variable" error in ci/bootstrap.sh

### DIFF
--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -78,7 +78,7 @@ if [[ -n ${BUILDKITE:-} ]]; then
     EXTRA_ARGS="--copy"
 fi
 
-if [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "darwin" ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_OS:-}" == "darwin" ]]; then
     PATH="${PATH}:/usr/local/share/dotnet"
 fi
 


### PR DESCRIPTION
#### Description

Fix "unbound variable" error when running ci/bootstrap on a non-windows non-buildkite machine

#### Tests

hit init
