### PR TITLE
Enable Accelerator

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -79,6 +79,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -91,6 +92,7 @@ steps:
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
+      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -101,6 +103,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -111,6 +114,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -121,3 +125,4 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,6 +30,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: &windows-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 macos: &macos
   agents:
@@ -44,6 +46,8 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
+  env: &macos-env
+    ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 linux: &linux
   agents:
@@ -75,11 +79,11 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -87,12 +91,12 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *macos-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
-      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -100,10 +104,10 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -111,10 +115,10 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -122,7 +126,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -7,7 +7,7 @@
 # You may find the example pipeline steps listed here helpful: https://buildkite.com/docs/pipelines/defining-steps#example-pipeline but please
 #  note that the setup is already done, so you should not manually adjust anything through the BuildKite interface.
 #
-common: &common
+windows: &windows
   agents:
     - "capable_of_building=gdk-for-unity"
     - "environment=production"
@@ -30,6 +30,8 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: &windows-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -37,57 +39,57 @@ common: &common
 steps:
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh
-    <<: *common
+    <<: *windows
     env:
       ASSEMBLY_PREFIX: "blank"
       PROJECT_NAME: "unity_gdk"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -46,6 +46,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -58,6 +59,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -69,6 +71,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -80,6 +83,7 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-accelerator 8ca3c40
+master f802ed7

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-master 7980ef5db74d8db47c0f683378a38d64accd2c0a
+accelerator 8ca3c40


### PR DESCRIPTION
#### Description

Provides `ACCELERATOR_ENDPOINT` argument to agents and provides the relevant arguments to use either the local/cloud Accelerators for mac/windows agents.

Depends on https://github.com/spatialos/gdk-for-unity-shared-ci/pull/72

#### Tests

Ran the pipeline. Multiple times.

#### Documentation

n/a
