### PR TITLE
Remove xr legacyinputhelpers package from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+### Removed
+
+- Removed the `com.unity.xr.legacyinputhelpers` package from the `manifest.json`. [#107](https://github.com/spatialos/gdk-for-unity-blank-project/pull/107)
+
 ## `0.3.6` - 2020-05-26
 
 ### Changed
 
 - Upgraded to GDK for Unity version `0.3.6`
+
 ## `0.3.5` - 2020-04-23
 
 ### Breaking Changes

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -4,7 +4,6 @@
     "com.unity.test-framework": "1.1.11",
     "com.unity.timeline": "1.2.10",
     "com.unity.ugui": "1.0.0",
-    "com.unity.xr.legacyinputhelpers": "2.0.8",
     "io.improbable.gdk.buildsystem": "0.3.6",
     "io.improbable.gdk.core": "0.3.6",
     "io.improbable.gdk.debug": "0.3.6",


### PR DESCRIPTION
#### Description

Remove xr legacyinputhelpers package from manifest

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
