### PR TITLE
UTY-2626: change sdk to 14.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `spatialos.json` sdk and standard library version updated to `14.6.1`. [#112](https://github.com/spatialos/gdk-for-unity-blank-project/pull/112)
+
 ## `0.3.7` - 2020-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Changed
-
-- `spatialos.json` sdk and standard library version updated to `14.6.1`. [#112](https://github.com/spatialos/gdk-for-unity-blank-project/pull/112)
-
 ## `0.3.7` - 2020-06-22
 
 ### Changed

--- a/spatialos.json
+++ b/spatialos.json
@@ -2,7 +2,4 @@
     "name": "unity_gdk",
     "project_version": "0.0.1",
     "sdk_version": "14.6.1",
-    "dependencies": [
-        {"name": "standard_library", "version": "14.6.1"}
-    ]
 }

--- a/spatialos.json
+++ b/spatialos.json
@@ -1,5 +1,5 @@
 {
     "name": "unity_gdk",
     "project_version": "0.0.1",
-    "sdk_version": "14.6.1",
+    "sdk_version": "14.6.1"
 }

--- a/spatialos.json
+++ b/spatialos.json
@@ -1,8 +1,8 @@
 {
     "name": "unity_gdk",
     "project_version": "0.0.1",
-    "sdk_version": "14.4.1",
+    "sdk_version": "14.6.1",
     "dependencies": [
-        {"name": "standard_library", "version": "14.4.1"}
+        {"name": "standard_library", "version": "14.6.1"}
     ]
 }


### PR DESCRIPTION
#### Description
- `spatialos.json` sdk and standard library version updated to `14.6.1`. [#112](https://github.com/spatialos/gdk-for-unity-blank-project/pull/112)

#### Tests
None

#### Documentation
- [ ] todo

- [x] **Did you remember a changelog entry?**

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
